### PR TITLE
Strip whitespace in css url()

### DIFF
--- a/inliner.js
+++ b/inliner.js
@@ -405,7 +405,7 @@ Inliner.prototype.getImagesFromCSS = function (rooturl, rawCSS, callback) {
   var inliner = this,
       images = {},
       urlMatch = /url\((?:['"]*)(?!['"]*data:)(.*?)(?:['"]*)\)/g,
-      singleURLMatch = /url\((?:['"]*)(?!['"]*data:)(.*?)(?:['"]*)\)/,
+      singleURLMatch = /url\(\s*(?:['"]*)(?!['"]*data:)(.*?)(?:['"]*)\s*\)/,
       matches = rawCSS.match(urlMatch),
       imageCount = matches === null ? 0 : matches.length; // TODO check!
   


### PR DESCRIPTION
Got errors when an url had whitespace:
get 403 on http://maptiles.finn.no/rel/head/css/ ../images/cloudpopnav.png

For this css value:
    background-image: url( ../images/cloudpopnav.png );

Notice the white space inside the url(). Allowed according to the spec: http://www.w3.org/TR/CSS21/syndata.html#uri
