### PR TITLE
Script escaping improvement, relevant to #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,6 @@ Once you've inlined the crap out of the page, add the `manifest="self.appcache"`
 
 - Whitespace compression might get a little heavy handed - all whitespace is collapsed from n spaces to one space.
   
+
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/Munter/inliner/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+

--- a/inliner.js
+++ b/inliner.js
@@ -216,7 +216,7 @@ function Inliner(url, options, callback) {
                   src = $script.attr('src'),
                   // note: not using .innerHTML as this coerses & => &amp;
                   orig_code = this.firstChild.nodeValue
-                                  .replace(/<\/script>/gi, '<\\/script>'),
+                                  .replace(/<\/(?=(\s*)script[\/ >])/gi, '<\\/'),
                   final_code = '';
 
               // only remove the src if we have a script body


### PR DESCRIPTION
In issue #11 @mathiasbynens points out that the escaping of script end tags in the script source only covers one of three cases.

I discovered that there are actually more cases, since white space is apparently allowed between `</` and `script`.

This update should cover all those cases.

By the way I stumbled upon this project because the html5boiler plate npm build system references it.
I am working on a project called assetgraph, which is a build system toolkit, and thought inliner would be a fun example for one of many tools that all need pretty much to do the same, and where assetgraph covers over 95% of the work already. My reimplementation of inliner can be found here: https://github.com/Munter/buildfu/blob/master/bin/inline

Thanks for the inspiration :)