### PR TITLE
Support relative <img src=> URLs.

### DIFF
--- a/inliner.js
+++ b/inliner.js
@@ -84,7 +84,9 @@ function Inliner(url, options, callback) {
 
       jsdom.env(html, [
         'http://code.jquery.com/jquery.min.js'
-      ], function(errors, window) {
+      ], {
+        url: url
+      }, function(errors, window) {
         // remove jQuery that was included with jsdom
         window.$('script:last').remove();
         


### PR DESCRIPTION
`img.src` is an absolute URL. jsdom's `img.src` getter produces this URL by resolving the `<img src=>` attribute value relative to the document's URL—which is bogus unless we explicitly pass a correct URL to `jsdom.env()` to start with.

(With this change, inliner works on http://people.mozilla.org/~jorendorff/es6-draft.html.)
