### PR TITLE
Change for null cases

### DIFF
--- a/inliner.js
+++ b/inliner.js
@@ -268,7 +268,7 @@ function Inliner(url, options, callback) {
         // but we're just being extra sure before we do zap it out  
         todo.scripts && assets.scripts.each(function () {
           var $script = window.$(this),
-              scriptURL = URL.resolve(url, this.src);
+              scriptURL = URL.resolve(url, (this.src||"").toString());
 
           if (!this.src || scriptURL.indexOf('google-analytics.com') !== -1) { // ignore google
             breakdown.scripts--;


### PR DESCRIPTION
In the case that this.src is null, need to go ahead and handle it gracefully.  Rather let url.js handle the null case than try to anticipate all the ways it could go wrong.
