### PR TITLE
callback on non 200 status

### DIFF
--- a/inliner.js
+++ b/inliner.js
@@ -427,6 +427,7 @@ Inliner.prototype.get = function (url, options, callback) {
       if (res.statusCode !== 200) {
         inliner.emit('progress', 'get ' + res.statusCode + ' on ' + url);
         body = ''; // ?
+        callback && callback(body);
       } else if (res.headers['location']) {
         return inliner.get(res.headers['location'], options, callback);
       } else {


### PR DESCRIPTION
fix end event never being emitted and callback not being triggered if any resource returned a non 200 status.

For example  when running inliner against http://remysharp.com the progress events show that three resources return non 200 status codes:
get 301 on http://twitter.com/api/users/profile_image/rem
get 301 on http://remy.github.com/twitterlib/twitterlib.min.js
get 404 on http://leftlogic.com/images/favicon.png

This updates Inliner.get() to call its callback with and empty string if the resource returns a non 200 response.
