### PR TITLE
fix: inline scripts containing ETAGO properly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -187,7 +187,7 @@ function main() {
     if (todo.styles.length) {
       debug('start %s styles', todo.styles.length);
       var stylePromises = todo.styles.map(function links(i, style) {
-        var css = $(style).html();
+        var css = $(style).text();
         inliner.emit('progress', 'processing inline css');
         return inliner.cssImports(url, css)
           .then(inliner.cssImages.bind(inliner, url))
@@ -204,7 +204,7 @@ function main() {
       var scriptPromises = todo.scripts.map(function links(i, script) {
         var $script = $(script);
         var src = $script.attr('src');
-        var source = $(script).html();
+        var source = $(script).text();
 
         var promise;
 
@@ -239,6 +239,10 @@ function main() {
         return promise.then(inliner.uglify.bind(inliner))
           .then(function then(res) {
           debug('uglify: %s', res);
+
+          // remove ETAGO (https://mathiasbynens.be/notes/etago)
+          res = res.replace(/<\/script/gi, '<\\/script');
+
           $script.text(res);
         });
       });

--- a/test/fixtures/script-local.js
+++ b/test/fixtures/script-local.js
@@ -3,3 +3,7 @@ var array = [4, 8, 15, 16, 23, 42];
 for (var i = 0; i < array.length; i++) {
     console.log(array[i]);
 }
+
+function surroundWithScriptTag(code) {
+    return '<script>' + code + '</script>';
+}

--- a/test/fixtures/script-local.result.html
+++ b/test/fixtures/script-local.result.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html> <html> <head> <meta charset="utf-8"> <title>min script</title> </head> <body> <script>for(var array=[4,8,15,16,23,42],i=0;i<array.length;i++)console.log(array[i]);</script> </body> </html>
+<!DOCTYPE html> <html> <head> <meta charset="utf-8"> <title>min script</title> </head> <body> <script>function surroundWithScriptTag(r){return"<script>"+r+"<\/script>"}for(var array=[4,8,15,16,23,42],i=0;i<array.length;i++)console.log(array[i]);</script> </body> </html>


### PR DESCRIPTION
The issue described in #11 is still a bug in 1.0.0.

The fix is done by escaping all "</script" to "<\/script" according to Mathias Bynens article :
https://mathiasbynens.be/notes/etago