### PR TITLE
fix: keep whitespaces and newlines in pre and textareas

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -255,12 +255,10 @@ function main() {
       inliner.removeComments($(':root')[0], $);
       // collapse the white space
       if (inliner.options.collapseWhitespace) {
-        // TODO put white space helper back in
-        $('pre').html(function tidyPre(i, html) {
-          return html.replace(/\n/g, '~~nl~~');
-        });
-        $('textarea').val(function tidyTextarea(i, v) {
-          return v.replace(/\n/g, '~~nl~~').replace(/\s/g, '~~s~~');
+        $('pre, textarea').each(function () {
+          $(this).html($(this).html()
+              .replace(/\n/g, '~~nl~~')
+              .replace(/\s/g, '~~s~~'));
         });
 
         html = $.html()

--- a/test/fixtures/html-whitespaces.result.html
+++ b/test/fixtures/html-whitespaces.result.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html> <html> <head> <meta charset="utf-8"> <title>html whitespaces</title> </head> <body> <div><code>// projector page window.addEventListener(&apos;storage&apos;, function (event) { if (event.key === &apos;currentSlide&apos;) { goToSlide(event.newValue); } });</code></div> <pre><code>// projector page
+
+    window.addEventListener(&apos;storage&apos;, function (event) {
+
+        if (event.key === &apos;currentSlide&apos;) {
+            goToSlide(event.newValue);
+        }
+    });</code></pre> <textarea><code>// projector page
+
+    window.addEventListener(&apos;storage&apos;, function (event) {
+
+        if (event.key === &apos;currentSlide&apos;) {
+            goToSlide(event.newValue);
+        }
+    });</code></textarea> </body> </html>

--- a/test/fixtures/html-whitespaces.src.html
+++ b/test/fixtures/html-whitespaces.src.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>html whitespaces</title>
+</head>
+<body>
+<div><code>// projector page
+
+    window.addEventListener('storage', function (event) {
+
+        if (event.key === 'currentSlide') {
+            goToSlide(event.newValue);
+        }
+    });</code></div>
+<pre><code>// projector page
+
+    window.addEventListener('storage', function (event) {
+
+        if (event.key === 'currentSlide') {
+            goToSlide(event.newValue);
+        }
+    });</code></pre>
+<textarea><code>// projector page
+
+    window.addEventListener('storage', function (event) {
+
+        if (event.key === 'currentSlide') {
+            goToSlide(event.newValue);
+        }
+    });</code></textarea>
+</body>
+</html>


### PR DESCRIPTION
The whitespace processing was not working :-(

Cheerio `.html()` setter does not seem to accept functions ([docs](https://github.com/cheeriojs/cheerio#html-htmlstring-) & [source](https://github.com/cheeriojs/cheerio/blob/master/lib/api/manipulation.js#L341)).

I also added whitespaces handling for pre (just like textarea). It was useful for my use case which contains indented code. Was it related to the comment I removed : `// TODO put white space helper back in`?