### PR TITLE
fix: replace with empty string if error in GET

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -54,12 +54,20 @@ module.exports = function get(url, options) {
         return reject(error);
       }
 
-      debug('response: %s %s', res.statusCode, url);
-      if (!error && res.statusCode === 200) {
-        resolve({ headers: res.headers, body: body });
-      } else {
-        return reject(new Error(res.statusCode));
+      if (!res) {
+        res = { headers: {}, statusCode: null };
       }
+
+      debug('response: %s %s', res.statusCode, url);
+      if (res.statusCode !== 200) {
+        body = '';
+      }
+
+      resolve({
+        body: body,
+        headers: res.headers,
+        statusCode: res.statusCode,
+      });
     });
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,6 +146,10 @@ function main() {
     var cheerioLoadOptions = {};
     var enc = inliner.options.encoding;
 
+    if (res.statusCode !== 200) {
+      inliner.emit('progress', res.statusCode + ' on ' + url);
+    }
+
     // try to determine the encoding from the headers and the body
     if (!enc) {
       enc = charset(res.headers, res.body);

--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -5,6 +5,11 @@ var UglifyJS = require('uglify-js');
 
 function uglify(source) {
   this.emit('progress', 'compressing javascript');
+
+  if (source.body === '') {
+    return '';
+  }
+
   if (source.body) {
     source = source.body;
   }

--- a/test/fixtures/get-error.result.html
+++ b/test/fixtures/get-error.result.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html> <html> <head> <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"> <meta charset="UTF-8"> <title>App</title> <style></style> <script></script> </head> <body> </body> </html>

--- a/test/fixtures/get-error.src.html
+++ b/test/fixtures/get-error.src.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta charset="UTF-8" />
+  <title>App</title>
+  <link rel="stylesheet" href="http://example.com/this_doesnt_exist" />
+  <script src="http://example.com/this_doesnt_exist"></script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Fixes #61

It seems to work, but I'm not sure if it's a clean way of doing it. Let
me know what you think @remy.