### PR TITLE
feat: implement HTML string inlining usecase

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,33 +111,48 @@ function main() {
   var inliner = this;
   var url = this.url;
 
-  fs.exists(url)
-  .then(function exists(isFile) {
-    if (!isFile) {
-      throw new Error();
-    }
+  // Handle the use case of directly inlining a HTML string
+  // instead of having to load it from an URL
+  if (this.url.substr(0,14).toLowerCase() === '<!doctype html') {
+    getHTML = new Promise(function (fulfill, reject) {
+      res = {
+        body: new Buffer(url),
+        headers: {
+          'content-type': 'text/html',
+        },
+      }
+      fulfill(res);
+    });
+  } else {
+    // Vanilla use of Inliner, passing it a URL as main input
+    getHTML = fs.exists(url)
+    .then(function exists(isFile) {
+      if (!isFile) {
+        throw new Error();
+      }
 
-    debug('inlining file');
+      debug('inlining file');
 
-    inliner.isFile = true;
-    return url;
-  })
-  .catch(function isUrl() {
-    // check for protocol on URL
-    if (url.indexOf('http') !== 0) {
-      url = 'http://' + url;
-    }
+      inliner.isFile = true;
+      return url;
+    })
+    .catch(function isUrl() {
+      // check for protocol on URL
+      if (url.indexOf('http') !== 0) {
+        url = 'http://' + url;
+      }
 
-    inliner.url = url;
+      inliner.url = url;
 
-    debug('inlining url');
-    return url;
-  })
-  .then(function (url) {
-    return inliner.get(url, { encoding: 'binary' });
-  })
-  .then(inliner.jobs.add('html'))
-  .then(function processHTML(res) {
+      debug('inlining url');
+      return url;
+    })
+    .then(function (url) {
+      return inliner.get(url, { encoding: 'binary' });
+    })
+    .then(inliner.jobs.add('html'))
+  }
+  getHTML.then(function processHTML(res) {
     inliner.jobs.done.html();
     debug('processing HTML');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,6 +20,11 @@ test('inliner core functions', function coreTests(t) {
   var inliner = new Inliner();
   t.ok(inliner, 'inline is instantiated');
 
+  var roundtripHTML = '<!DOCTYPE html><html></html>';
+  new Inliner(roundtripHTML, function(error, html) {
+    t.equal(html, roundtripHTML, 'recognizes HTML as main input');
+  });
+
   t.end();
 });
 


### PR DESCRIPTION
A rudimentary attempt to support the usecase of using Inliner to directly inline a HTML string, by passing it as the main argument (instead of a URL which is fetched first). Might implement: https://github.com/remy/inliner/issues/66