### PR TITLE
feat: support plain HTML as a source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - iojs-v2
-  - iojs-v1
+  - 4
   - '0.12'
   - '0.10'
 before_install:

--- a/cli/index.js
+++ b/cli/index.js
@@ -38,11 +38,11 @@ function main() {
 
       var data = '';
 
-      process.stdin.on('data', function(chunk) {
+      process.stdin.on('data', function (chunk) {
         data += chunk;
       });
 
-      process.stdin.on('end', function() {
+      process.stdin.on('end', function () {
         resolve(data);
       });
     });

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var readFileSync = require('fs').readFileSync;
+var Promise = require('es6-promise').Promise; // jshint ignore:line
 
 main();
 
@@ -18,7 +19,7 @@ function main() {
     process.exit(0);
   }
 
-  if (!url || argv.help) {
+  if ((!url && !argv.useStdin) || argv.help) {
     var usage = readFileSync(
       __dirname + '/../docs/usage.txt', 'utf8'
     );
@@ -28,42 +29,66 @@ function main() {
 
   var Inliner = require('../');
 
-  var inliner = new Inliner(url, argv, function result(error, html) {
-    if (error) {
-      var message = Inliner.errors[error.code] || error.message;
-      console.error(message);
+  var p = Promise.resolve(url);
 
-      if (argv.debug) {
-        console.error(error.stack);
-      }
+  if (argv.useStdin) {
+    p = new Promise(function (resolve) {
+      process.stdin.resume();
+      process.stdin.setEncoding('utf8');
 
-      process.exit(1);
-    }
+      var data = '';
 
-    console.log(html);
-  });
+      process.stdin.on('data', function(chunk) {
+        data += chunk;
+      });
 
-  // checks for available update and returns an instance
-  // note: we're doing this after we kick off inliner, since there's a
-  // noticeable lag in boot because of it
-  var defaults = require('lodash.defaults');
-  var pkg = JSON.parse(readFileSync(__dirname + '/../package.json'));
-
-  require('update-notifier')({
-    pkg: defaults(pkg, { version: '0.0.0' }),
-  }).notify();
-
-  inliner.on('warning', function progress(event) {
-    console.warn('warning: ' + event);
-  });
-
-  if (argv.verbose) {
-    inliner.on('progress', function progress(event) {
-      console.error(event);
-    });
-
-    inliner.on('jobs', function jobs(event) {
-      console.error(event);
+      process.stdin.on('end', function() {
+        resolve(data);
+      });
     });
   }
+
+  p.then(function (source) {
+    var inliner = new Inliner(source, argv, function result(error, html) {
+      if (error) {
+        var message = Inliner.errors[error.code] || error.message;
+        console.error(message);
+
+        if (argv.debug) {
+          console.error(error.stack);
+        }
+
+        process.exit(1);
+      }
+
+      console.log(html);
+    });
+
+    return inliner;
+  }).then(function (inliner) {
+    // checks for available update and returns an instance
+    // note: we're doing this after we kick off inliner, since there's a
+    // noticeable lag in boot because of it
+    var defaults = require('lodash.defaults');
+    var pkg = JSON.parse(readFileSync(__dirname + '/../package.json'));
+
+    require('update-notifier')({
+      pkg: defaults(pkg, { version: '0.0.0' }),
+    }).notify();
+
+    inliner.on('warning', function progress(event) {
+      console.warn('warning: ' + event);
+    });
+
+    if (argv.verbose) {
+      inliner.on('progress', function progress(event) {
+        console.error(event);
+      });
+
+      inliner.on('jobs', function jobs(event) {
+        console.error(event);
+      });
+    }
+  });
+
 }

--- a/cli/options.js
+++ b/cli/options.js
@@ -35,5 +35,7 @@ function options(args) {
   }
   argv.images = !argv.noimages;
 
+  argv.useStdin = !process.stdin.isTTY;
+
   return argv;
 }

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -3,6 +3,8 @@
 
     $ inliner [flags] url-or-filename
 
+  Inliner also supports HTML being piped and will inline from STDIN.
+
   Flags:
 
     -n, --nocompress  don't compress CSS or HTML - useful for debugging
@@ -21,5 +23,6 @@
     $ inliner -v https://twitter.com > twitter.html
     $ inliner -ni local-file.html > local-file.min.html
     $ inliner -e windows-1253 http://foofootos.gr > foofootos-utf8.html
+    $ cat local-file.html | inliner
 
   For more details see http://github.com/remy/inliner/

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,9 +29,16 @@ var taskRunner = Object.keys(tasks).reduce(function (acc, curr) {
   return acc;
 }, {});
 
-function Inliner(url, options, callback) {
+// source is typicaly a URL, but can be a file location OR an HTML string
+function Inliner(source, options, callback) {
   var inliner = this;
   events.EventEmitter.call(this);
+
+  // allow for source to be optional
+  if (typeof source !== 'string') {
+    callback = options;
+    options = source;
+  }
 
   if (typeof options === 'function') {
     callback = options;
@@ -42,7 +49,20 @@ function Inliner(url, options, callback) {
     options = {};
   }
 
-  this.url = url;
+  if (options.url) {
+    this.url = options.url;
+  }
+
+  if (options.filename) {
+    this.filename = options.filename;
+  }
+
+  if (options.source) {
+    this.source = options.source;
+  } else {
+    this.source = source;
+  }
+
   this.callback = function wrapper(error, res) {
     // noop the callback once it's fired
     inliner.callback = function noop() {
@@ -74,7 +94,7 @@ function Inliner(url, options, callback) {
 
   // this allows the user code to get the object back before
   // it starts firing events
-  if (this.url) {
+  if (this.source) {
     if (typeof setImmediate === 'undefined') {
       global.setImmediate = function setImmediatePolyfill(fn) {
         // :-/
@@ -108,9 +128,9 @@ Inliner.defaults = require('./defaults');
 // main thread of functionality that does all the inlining
 function main() {
   var inliner = this;
-  var url = this.url;
+  var url = this.source;
 
-  fs.exists(url)
+  fs.exists(this.filename || url)
   .then(function exists(isFile) {
     if (!isFile) {
       throw new Error();
@@ -119,21 +139,34 @@ function main() {
     debug('inlining file');
 
     inliner.isFile = true;
-    return url;
+    inliner.url = url; // this is a hack for the `resolve` function later on
+    return inliner.get(this.filename || url, { encoding: 'binary' });
   })
   .catch(function isUrl() {
-    // check for protocol on URL
-    if (url.indexOf('http') !== 0) {
-      url = 'http://' + url;
+    // make the best guess as to whether we're working with a url
+    if (inliner.url || url.indexOf('<') === -1) {
+      url = inliner.url || inliner.source;
+      // check for protocol on URL
+      if (url.indexOf('http') !== 0) {
+        url = 'http://' + url;
+      }
+
+      inliner.url = url;
+
+      debug('inlining url');
+      return inliner.get(url, { encoding: 'binary' });
     }
 
-    inliner.url = url;
-
-    debug('inlining url');
-    return url;
-  })
-  .then(function (url) {
-    return inliner.get(url, { encoding: 'binary' });
+    // otherwise we're dealing with an inline string
+    debug('inlining by string: ', inliner.source);
+    inliner.url = '.';
+    var res = {
+      body: new Buffer(inliner.source),
+      headers: {
+        'content-type': 'text/html',
+      },
+    };
+    return res;
   })
   .then(inliner.jobs.add('html'))
   .then(function processHTML(res) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,6 +13,8 @@ test.createStream().pipe(tapSpec()).pipe(process.stdout);
 test('inliner core functions', function coreTests(t) {
   var Inliner = require('../');
 
+  t.plan(4);
+
   t.equal(typeof Inliner, 'function', 'Inliner is a function');
   t.equal(Inliner.version,
     require('../package.json').version, 'should have version');
@@ -20,7 +22,10 @@ test('inliner core functions', function coreTests(t) {
   var inliner = new Inliner();
   t.ok(inliner, 'inline is instantiated');
 
-  t.end();
+  var roundtripHTML = '<!DOCTYPE html><html></html>';
+  new Inliner(roundtripHTML, function(error, html) {
+    t.equal(html, roundtripHTML, 'recognizes HTML as main input');
+  });
 });
 
 test('inliner fixtures', function fixtureTests(t) {


### PR DESCRIPTION
Supports both HTML being passed as the first argument to the inliner function (through various detection), but also on the CLI supports HTML being piped, via `cat foo | inliner`.

Fixes #66
Closes #73