### PR TITLE
feat: resolve external absolute path by baseURL

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -68,13 +68,12 @@ function getImports(root, css) {
       css = css.replace('@import ' + match, importedCSS);
       return getImports.call(inliner, root, css);
     });
-  } else {
-    if (inliner.options.compressCSS) {
-      inliner.emit('progress', 'compress css');
-      css = compress(css);
-    }
-    return Promise.resolve(css);
   }
+  if (inliner.options.compressCSS) {
+    inliner.emit('progress', 'compress css');
+    css = compress(css);
+  }
+  return Promise.resolve(css);
 }
 
 function compress(css) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,10 @@ function Inliner(source, options, callback) {
     this.source = source;
   }
 
+  if (options.baseURL) {
+    this.baseURL = options.baseURL;
+  }
+
   this.callback = function wrapper(error, res) {
     // noop the callback once it's fired
     inliner.callback = function noop() {
@@ -306,6 +310,10 @@ function resolve(from, to) {
   if (!to) {
     to = from;
     from = this.url;
+  }
+
+  if (this.baseURL) {
+    from = this.baseURL;
   }
 
   // don't resolve data urls (already inlined)

--- a/lib/index.js
+++ b/lib/index.js
@@ -328,10 +328,10 @@ function resolve(from, to) {
 
   if (!this.isFile || from.indexOf('http') === 0) {
     return require('url').resolve(from, to);
-  } else {
-    var base = path.dirname(from);
-    return path.resolve(base, to);
   }
+
+  var base = path.dirname(from);
+  return path.resolve(base, to);
 
 }
 

--- a/test/fixtures/css-ext-absolute-import.opts.json
+++ b/test/fixtures/css-ext-absolute-import.opts.json
@@ -1,0 +1,3 @@
+{
+    "baseURL": "http://localhost:54321"
+}

--- a/test/fixtures/css-ext-absolute-import.result.html
+++ b/test/fixtures/css-ext-absolute-import.result.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html> <html> <head> <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"> <meta charset="UTF-8"> <title>App</title> <style>p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}</style> </head> <body> body </body> </html>

--- a/test/fixtures/css-ext-absolute-import.src.html
+++ b/test/fixtures/css-ext-absolute-import.src.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta charset="UTF-8" />
+  <title>App</title>
+  <link rel="stylesheet" href="/css-ext-import.css" />
+</head>
+<body>
+body
+</body>
+</html>


### PR DESCRIPTION
I want to do inlining a local html file. but the html has some external absolute links. 
`inliner.get` happens error INVALID URL in this situation.

I resoved the problem with overwrite `Inliner.prototyep.resolve` as follows:

```javascript
const path = require('path');
const Inliner = require('inliner');

// add
let baseURL;

Inliner.prototype.resolve = (from, to) => {
  if (!to) {
    to = from;
    from = this.url;
  }
  // add
  if (this.baseURL) {
    from = this.baseURL;
  }
  ...
}

// this is my own code
myinline = (html, opts, callback) => {
  baseURL = opts.baseURL;
  new Inliner(url, (err, result) => {
    if (err) {
      return callback(err);
    }
  callback(null, result);
  });
}
```

this way is working. but actually, I want new argument `baseURL`.

```javascript
var Inliner = require('./lib/index');

new Inliner('<html><head><link rel="stylesheet" href="/simple.css" /></head><body></body></html>', {baseURL: 'http://localhost:8000'}, function (err, html) { 
  console.log(html); // <html><head><style>body{ color:#333;}</style></head><body></body></html>
});
```

So I suggest this PR. Please check it if you think it is worth.

