### PR TITLE
Allow string inputs to resolve relative local paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -192,7 +192,12 @@ function main() {
 
     // otherwise we're dealing with an inline string
     debug('inlining by string: ', inliner.source);
-    inliner.url = '.';
+    inliner.isFile = true; // Allow relative paths are resolved.
+    if (inliner.filename) {
+        inliner.url = inliner.filename;
+    } else {
+        inliner.url = '.';
+    }
     var res = {
       body: new Buffer(inliner.source),
       headers: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inliner",
-  "version": "v1.8.1-gh"
+  "version": "v1.8.1-gh",
   "description": "Utility to inline images, CSS and JavaScript for a web page - useful for mobile sites",
   "homepage": "http://github.com/remy/inliner",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "inliner",
+  "version": "v1.8.1-gh"
   "description": "Utility to inline images, CSS and JavaScript for a web page - useful for mobile sites",
   "homepage": "http://github.com/remy/inliner",
   "main": "lib/index.js",


### PR DESCRIPTION
Sometimes an inline string is contains relative paths to a local file
system location. By setting inliner.filename to a proper local path,
allow the regular file based URL resolution to take place.

In our case, we are generating the inline string using some JS, and
using inliner on the generated code. It looks a bit lie:

```javascript
var renderOutput = render(...);
var Inliner = require('inliner');
new Inliner({'source': renderOutput, 'filename': localPath + '/placeholder.html'},
            function (error, html) {
    console.log(html);
    if(error) {
        console.error(error);
    }
});
```

By setting filename, we get relative css and js includes in our renderOutput to be resolved based on the lies in `localPath`.

Note this is addressing issue https://github.com/remy/inliner/issues/89 - but for my use case...