### PR TITLE
fix: detect xml-mode with XML declaration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -236,7 +236,7 @@ function main() {
 
     // if we spot some SVG elements in the source,
     // then we'll parse as XML to correctly get the SVG
-    if (body.indexOf('<svg') !== -1 || body.indexOf('<SVG') !== -1) {
+    if (body.indexOf('<?xml') !== -1 || body.indexOf('<?XML') !== -1) {
       cheerioLoadOptions.xmlMode = true;
     }
 

--- a/test/fixtures/xml-detection.result.html
+++ b/test/fixtures/xml-detection.result.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html> <html> <head> <meta charset="utf-8"> <title>xml detection</title> </head> <body> <svg width="10" height="20"/> <div></div> </body> </html>

--- a/test/fixtures/xml-detection.src.html
+++ b/test/fixtures/xml-detection.src.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>xml detection</title>
+</head>
+<body>
+  <svg width="10" height="20"></svg>
+  <div></div>
+</body>
+</html>


### PR DESCRIPTION
Fix miss-detection of document type when `<svg>` tag(s) are included.  When some `<svg>` tags are included even in HTML document, the document is treated as XML document.  That problem causes that the following code

```HTML
<svg></svg>
<div></div>
```

is converted to

```HTML
<svg/> <div/>
```

The converted version is incorrect HTML document.
