### PR TITLE
fix: don't inline background images when the images option is false

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -10,6 +10,11 @@ var debug = require('debug')('inliner');
 
 function getImages(root, css) {
   var inliner = this;
+
+  if (inliner.options.images === false) {
+    return css;
+  }
+
   var singleURLMatch = /url\(\s*(['"]*)(?!['"]*data:)(.*?)(['"]*)\s*\)/;
   var matches = css.match(match) || [];
   var images = matches.map(function eachURL(url) {

--- a/test/fixtures/bg-img-no-inline.opts.json
+++ b/test/fixtures/bg-img-no-inline.opts.json
@@ -1,0 +1,3 @@
+{
+  "images": false
+}

--- a/test/fixtures/bg-img-no-inline.result.html
+++ b/test/fixtures/bg-img-no-inline.result.html
@@ -1,0 +1,1 @@
+<!doctype html> <meta name="charset" content="utf-8"> <style> body{ background-image:url('./image.jpg');}</style>

--- a/test/fixtures/bg-img-no-inline.src.html
+++ b/test/fixtures/bg-img-no-inline.src.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta name="charset" content="utf-8">
+<style>
+  body {
+    background-image: url('./image.jpg');
+  }
+</style>


### PR DESCRIPTION
This fixes #105 for me. It's probably not how you'd do it, but it's working.