### PR TITLE
Decode URI encoding before loading file locally

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -31,7 +31,7 @@ module.exports = function get(url, options) {
 
   if (this.isFile && url.indexOf('http') !== 0) {
     debug('inliner.get file: %s', url);
-    cache[url] = fs.readFile(url).then(function read(body) {
+    cache[url] = fs.readFile(decodeURI(url)).then(function read(body) {
       return {
         body: body,
         headers: {


### PR DESCRIPTION
Otherwise files with spaces and non-alphanumeric names will fail