### PR TITLE
Apple device specific link images to data urls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,8 @@ var tasks = {
   js: 'script',
   svg: 'svg',
   links: 'link[rel=stylesheet]',
-  favicon: 'link[rel=icon],link[rel="shortcut icon"],link[rel="apple-touch-icon"],link[rel="apple-touch-startup-image"]',
+  favicon: 'link[rel=icon],link[rel="shortcut icon"],' +
+    'link[rel="apple-touch-icon"],link[rel="apple-touch-startup-image"]',
   styles: 'style',
   'style-attrs': '[style]:not(svg *)',  // only style attrs in HTML, not SVG
   images: 'img',

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ var tasks = {
   js: 'script',
   svg: 'svg',
   links: 'link[rel=stylesheet]',
-  favicon: 'link[rel=icon],link[rel="shortcut icon"]',
+  favicon: 'link[rel=icon],link[rel="shortcut icon"],link[rel="apple-touch-icon"],link[rel="apple-touch-startup-image"]',
   styles: 'style',
   'style-attrs': '[style]:not(svg *)',  // only style attrs in HTML, not SVG
   images: 'img',


### PR DESCRIPTION
Implemented simply by adding targets to favicon list as it is already used also for other images that are not favicons.