### PR TITLE
Fix: move Get cache to the Inliner instance

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -6,10 +6,10 @@ var fs = require('then-fs');
 var mime = require('mime');
 var basename = require('path').basename;
 
-var cache = {};
-
 module.exports = function get(url, options) {
   var inliner = this;
+  var cache = inliner.cache;
+
   if (url.indexOf('data:') === 0) {
     debug('asset already inline', url);
     return Promise.resolve({

--- a/lib/index.js
+++ b/lib/index.js
@@ -130,6 +130,7 @@ function Inliner(source, options, callback) {
   }.bind(this));
 
   this.isFile = options.useStdin || false;
+  this.cache = {};
 
   this.on('error', function localErrorHandler(event) {
     inliner.callback(event);


### PR DESCRIPTION
New PR of #167 to keep the history clean 

Currently the Get results are being cached in a singleton~ which means any changes to the files/paths are not picked up if the same process invokes the Inliner again.   

Solved by moving the Get cache to the `Inliner`.


@remy How would you suggest writing a test for this? The scenario involves 

```
Inliner = require('inliner')

// index.html has a stylesheet link to styles.css
inline('index.html') 

// modify styles.css
inline('index.html') 
```

which doesn't play nicely with the current fixtures set up 😢 