### PR TITLE
Fixes issue fetching urls without a user-agent

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -65,7 +65,9 @@ module.exports = function get(url, options) {
   var settings = assign({}, options, {
     encoding: null,
     followRedirect: true,
-    headers: inliner.headers,
+    headers: assign({}, inliner.headers, {
+      'user-agent': 'facebookexternalhit'
+    })
   });
 
   debug('request %s', url, settings);


### PR DESCRIPTION
Some websites are not fans of crawlers or they block certain user agents.

```
inliner https://soundcloud.com/smixx/smixx-developers-feat-steve
warning: 400 on smixx-developers-feat-steve
Cannot read property 'toLowerCase' of null
```