### PR TITLE
Update CSS match regex to avoid mangling anchor URL's in CSS

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -1,4 +1,4 @@
-var match = /url\((?:['"]*)(?!['"]*data:)(.*?)(?:['"]*)\)/g;
+var match = /url\((?:['"]*)(?!['"]*data:)(?:[^"'#].*?)(?:['"]*)\)/g;
 
 module.exports = {
   getImages: getImages,


### PR DESCRIPTION
This is a proposed fix for the issue I opened: #185 

Basically, it doesn't touch CSS URL's that start with a "#" character so things like same-page anchor targets are left alone.