### PR TITLE
Make `inlinemin:true` default

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -8,5 +8,6 @@ module.exports = function () {
     skipAbsoluteUrls: false,
     preserveComments: false,
     iesafe: false,
+    inlinemin: true,
   };
 };


### PR DESCRIPTION
Per [this comment](https://github.com/remy/inliner/issues/109#issuecomment-238625124), and the associated issue, it seems like a good idea to default this. If this is rejected, can we add a note to the readme to help others save time trying to debug this? Just spent about an hour or so trying to work out why one of my script files was being skipped. Also didn't realise that the options object names are the same as those accepted by the cli until I dug into the source, so mabe that's worth mentioning in the readme too (happy to do a pull request for this if you want). In any case, thanks for the excellent tool!