### PR TITLE
fix: update cheerio and svgo to fix vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ansi-styles": "^2.2.1",
     "chalk": "^1.1.3",
     "charset": "^1.0.0",
-    "cheerio": "^0.19.0",
+    "cheerio": "^0.22.0",
     "debug": "^2.2.0",
     "es6-promise": "^2.3.0",
     "iconv-lite": "^0.4.11",
@@ -43,7 +43,7 @@
     "mime": "^1.3.4",
     "minimist": "^1.1.3",
     "request": "^2.74.0",
-    "svgo": "^0.6.6",
+    "svgo": "^1.2.2",
     "then-fs": "^2.0.0",
     "uglify-js": "^2.8.0",
     "update-notifier": "^0.5.0"


### PR DESCRIPTION
Reported by npm audit

cheerio  0.14.0 - 0.19.0
  Depends on vulnerable versions of lodash
lodash  <=4.17.18
Prototype Pollution - https://npmjs.com/advisories/1065
Prototype Pollution - https://npmjs.com/advisories/1523
Prototype Pollution - https://npmjs.com/advisories/577
Prototype Pollution - https://npmjs.com/advisories/782

svgo  0.4.2 - 1.0.5
  Depends on vulnerable versions of js-yaml
js-yaml  <=3.13.0
Denial of Service - https://npmjs.com/advisories/788
Code Injection - https://npmjs.com/advisories/813